### PR TITLE
🐛 Fix duplicate wake word responses

### DIFF
--- a/jarvis_assistant.py
+++ b/jarvis_assistant.py
@@ -60,7 +60,7 @@ class EnhancedJarvisAssistant:
         
         # Set up STT callbacks
         self.stt.set_speech_callback(self.on_speech_received)
-        self.stt.set_wake_word_callback(self.on_wake_word_detected)
+        # Note: Wake word detection handled in on_speech_received, not separately
         
         # Enhanced TTS callbacks for better state management
         self.tts.set_speech_callbacks(

--- a/speech_analysis/stt.py
+++ b/speech_analysis/stt.py
@@ -619,20 +619,19 @@ class JarvisSTT:
                     if transcription:
                         logger.info(f"Transcribed: '{transcription}'")
                         
-                        # Check for wake word first
-                        if self.wake_detector.detect(transcription):
-                            if self.on_wake_word_callback:
-                                try:
-                                    self.on_wake_word_callback()
-                                except Exception as e:
-                                    logger.error(f"Wake word callback error: {e}")
-                        
-                        # Call speech callback
+                        # Call speech callback (wake word detection handled at assistant level)
                         if self.on_speech_callback:
                             try:
                                 self.on_speech_callback(transcription)
                             except Exception as e:
                                 logger.error(f"Speech callback error: {e}")
+                        
+                        # Only call wake word callback if no speech callback is set (for backwards compatibility)
+                        elif self.on_wake_word_callback and self.wake_detector.detect(transcription):
+                            try:
+                                self.on_wake_word_callback()
+                            except Exception as e:
+                                logger.error(f"Wake word callback error: {e}")
                 
                 self.processing_queue.task_done()
                 


### PR DESCRIPTION
Problem: When users said commands containing "Jarvis" (like "Hi, Jarvis"), the system was responding twice because both the STT layer and assistant layer were independently detecting wake words.

Root cause: Double wake word detection - the STT layer would detect the wake word and call on_wake_word_callback(), while the assistant layer would also detect the wake word in on_speech_received() and process it as both a wake word activation AND a command.

Solution:
- Centralized wake word detection to assistant layer only
- STT layer now defers wake word detection to speech callback
- Maintains backwards compatibility for cases without speech callback
- Eliminates duplicate responses to commands like "Hi, Jarvis"

Files changed:
- jarvis_assistant.py: Removed duplicate wake word callback setup
- speech_analysis/stt.py: Modified to prioritize speech callback over wake word detection

🤖 Generated with Claude Code